### PR TITLE
Add Google Analytics with cookie consent banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Environment Variables for AI App Builder
 
-# Google Analytics
-VITE_GOOGLE_ANALYTICS_ID="YOUR-GA-ID-HERE"
+# Google Analytics (optional - cookie banner will only show if this is set)
+# VITE_GOOGLE_ANALYTICS_ID="YOUR-GA-ID-HERE"
 
 # OpenAI or OpenRouter API Key
 VITE_CALLAI_API_KEY=your_openai_or_openrouter_key_here

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Environment Variables for AI App Builder
+
+# Google Analytics
+VITE_GOOGLE_ANALYTICS_ID="YOUR-GA-ID-HERE"
+
+# OpenAI or OpenRouter API Key
+VITE_CALLAI_API_KEY=your_openai_or_openrouter_key_here
+
+# Fireproof database name
+VITE_VIBES_CHAT_HISTORY=vibes-chats

--- a/app/components/ClientOnly.tsx
+++ b/app/components/ClientOnly.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+interface ClientOnlyProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * ClientOnly component to ensure client-side only code doesn't run during SSR
+ */
+export default function ClientOnly({ children, fallback = null }: ClientOnlyProps) {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  if (!hasMounted) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/app/components/CookieBanner.tsx
+++ b/app/components/CookieBanner.tsx
@@ -11,11 +11,11 @@ export default function CookieBanner() {
   const [hasConsent, setHasConsent] = useState(false);
   const { messageHasBeenSent } = useCookieConsent();
   const [isDarkMode, setIsDarkMode] = useState(false);
-  
+
   // Dynamic import for client-side only
   const [CookieConsent, setCookieConsent] = useState<any>(null);
   const [getCookieConsentValue, setGetCookieConsentValue] = useState<any>(null);
-  
+
   // Detect dark mode
   useEffect(() => {
     // Check initial theme
@@ -23,9 +23,9 @@ export default function CookieBanner() {
       const hasDarkClass = document.documentElement.classList.contains('dark');
       setIsDarkMode(hasDarkClass);
     };
-    
+
     checkTheme();
-    
+
     // Set up observer for theme changes
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -34,12 +34,12 @@ export default function CookieBanner() {
         }
       });
     });
-    
+
     observer.observe(document.documentElement, { attributes: true });
-    
+
     return () => observer.disconnect();
   }, []);
-  
+
   // Load the cookie consent library on client side only
   useEffect(() => {
     import('react-cookie-consent').then((module) => {
@@ -47,7 +47,7 @@ export default function CookieBanner() {
       setGetCookieConsentValue(() => module.getCookieConsentValue);
     });
   }, []);
-  
+
   // Check for existing cookie consent
   useEffect(() => {
     if (getCookieConsentValue) {
@@ -58,14 +58,14 @@ export default function CookieBanner() {
       }
     }
   }, [getCookieConsentValue]);
-  
+
   // Track page views when location changes (only if consent was given)
   useEffect(() => {
     if (hasConsent) {
       pageview(location.pathname + location.search);
     }
   }, [location, hasConsent]);
-  
+
   // Add GA script if consent is given
   useEffect(() => {
     if (hasConsent && typeof document !== 'undefined') {
@@ -73,49 +73,51 @@ export default function CookieBanner() {
       script.async = true;
       script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`;
       document.head.appendChild(script);
-      
+
       // Define window.dataLayer with proper TypeScript type
       interface WindowWithDataLayer extends Window {
         dataLayer: any[];
         gtag: (...args: any[]) => void;
       }
-      
+
       const windowWithDataLayer = window as unknown as WindowWithDataLayer;
       windowWithDataLayer.dataLayer = windowWithDataLayer.dataLayer || [];
-      
+
       function gtag(...args: any[]) {
         windowWithDataLayer.dataLayer.push(arguments);
       }
-      
+
       windowWithDataLayer.gtag = gtag;
       gtag('js', new Date());
       gtag('config', GA_TRACKING_ID);
     }
   }, [hasConsent]);
-  
+
   // Don't render anything if any of these conditions are met:
   // 1. CookieConsent is not loaded
   // 2. No message has been sent yet
   // 3. Google Analytics ID is not set (making analytics optional)
   if (!CookieConsent || !messageHasBeenSent || !GA_TRACKING_ID) return null;
-  
+
   return (
     <CookieConsent
       location="bottom"
       buttonText="Accept"
       declineButtonText="Decline"
       cookieName="cookieConsent"
-      style={{ 
+      style={{
         background: isDarkMode ? '#1a1a1a' : '#ffffff',
         color: '#808080',
-        boxShadow: isDarkMode ? '0 -1px 10px rgba(255, 255, 255, 0.1)' : '0 -1px 10px rgba(0, 0, 0, 0.1)'
+        boxShadow: isDarkMode
+          ? '0 -1px 10px rgba(255, 255, 255, 0.1)'
+          : '0 -1px 10px rgba(0, 0, 0, 0.1)',
       }}
-      buttonStyle={{ 
-        color: isDarkMode ? '#ffffff' : '#000000', 
-        backgroundColor: isDarkMode ? '#333333' : '#e0e0e0', 
+      buttonStyle={{
+        color: isDarkMode ? '#ffffff' : '#000000',
+        backgroundColor: isDarkMode ? '#333333' : '#e0e0e0',
         fontSize: '13px',
         borderRadius: '4px',
-        padding: '8px 16px'
+        padding: '8px 16px',
       }}
       declineButtonStyle={{
         color: '#808080',
@@ -123,7 +125,7 @@ export default function CookieBanner() {
         fontSize: '13px',
         border: '1px solid #808080',
         borderRadius: '4px',
-        padding: '7px 15px'
+        padding: '7px 15px',
       }}
       expires={365}
       enableDeclineButton

--- a/app/components/CookieBanner.tsx
+++ b/app/components/CookieBanner.tsx
@@ -93,8 +93,11 @@ export default function CookieBanner() {
     }
   }, [hasConsent]);
   
-  // Don't render anything if CookieConsent is not loaded or no message has been sent yet
-  if (!CookieConsent || !messageHasBeenSent) return null;
+  // Don't render anything if any of these conditions are met:
+  // 1. CookieConsent is not loaded
+  // 2. No message has been sent yet
+  // 3. Google Analytics ID is not set (making analytics optional)
+  if (!CookieConsent || !messageHasBeenSent || !GA_TRACKING_ID) return null;
   
   return (
     <CookieConsent

--- a/app/components/CookieBanner.tsx
+++ b/app/components/CookieBanner.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+import { initGA, pageview } from '../utils/analytics';
+import { GA_TRACKING_ID } from '../config/analytics';
+import { useCookieConsent } from '../context/CookieConsentContext';
+
+// We'll use any type for dynamic imports to avoid TypeScript errors with the cookie consent component
+
+export default function CookieBanner() {
+  const location = useLocation();
+  const [hasConsent, setHasConsent] = useState(false);
+  const { messageHasBeenSent } = useCookieConsent();
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  
+  // Dynamic import for client-side only
+  const [CookieConsent, setCookieConsent] = useState<any>(null);
+  const [getCookieConsentValue, setGetCookieConsentValue] = useState<any>(null);
+  
+  // Detect dark mode
+  useEffect(() => {
+    // Check initial theme
+    const checkTheme = () => {
+      const hasDarkClass = document.documentElement.classList.contains('dark');
+      setIsDarkMode(hasDarkClass);
+    };
+    
+    checkTheme();
+    
+    // Set up observer for theme changes
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.attributeName === 'class') {
+          checkTheme();
+        }
+      });
+    });
+    
+    observer.observe(document.documentElement, { attributes: true });
+    
+    return () => observer.disconnect();
+  }, []);
+  
+  // Load the cookie consent library on client side only
+  useEffect(() => {
+    import('react-cookie-consent').then((module) => {
+      setCookieConsent(() => module.default);
+      setGetCookieConsentValue(() => module.getCookieConsentValue);
+    });
+  }, []);
+  
+  // Check for existing cookie consent
+  useEffect(() => {
+    if (getCookieConsentValue) {
+      const consentValue = getCookieConsentValue('cookieConsent');
+      if (consentValue === 'true') {
+        setHasConsent(true);
+        initGA();
+      }
+    }
+  }, [getCookieConsentValue]);
+  
+  // Track page views when location changes (only if consent was given)
+  useEffect(() => {
+    if (hasConsent) {
+      pageview(location.pathname + location.search);
+    }
+  }, [location, hasConsent]);
+  
+  // Add GA script if consent is given
+  useEffect(() => {
+    if (hasConsent && typeof document !== 'undefined') {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`;
+      document.head.appendChild(script);
+      
+      // Define window.dataLayer with proper TypeScript type
+      interface WindowWithDataLayer extends Window {
+        dataLayer: any[];
+        gtag: (...args: any[]) => void;
+      }
+      
+      const windowWithDataLayer = window as unknown as WindowWithDataLayer;
+      windowWithDataLayer.dataLayer = windowWithDataLayer.dataLayer || [];
+      
+      function gtag(...args: any[]) {
+        windowWithDataLayer.dataLayer.push(arguments);
+      }
+      
+      windowWithDataLayer.gtag = gtag;
+      gtag('js', new Date());
+      gtag('config', GA_TRACKING_ID);
+    }
+  }, [hasConsent]);
+  
+  // Don't render anything if CookieConsent is not loaded or no message has been sent yet
+  if (!CookieConsent || !messageHasBeenSent) return null;
+  
+  return (
+    <CookieConsent
+      location="bottom"
+      buttonText="Accept"
+      declineButtonText="Decline"
+      cookieName="cookieConsent"
+      style={{ 
+        background: isDarkMode ? '#1a1a1a' : '#ffffff',
+        color: '#808080',
+        boxShadow: isDarkMode ? '0 -1px 10px rgba(255, 255, 255, 0.1)' : '0 -1px 10px rgba(0, 0, 0, 0.1)'
+      }}
+      buttonStyle={{ 
+        color: isDarkMode ? '#ffffff' : '#000000', 
+        backgroundColor: isDarkMode ? '#333333' : '#e0e0e0', 
+        fontSize: '13px',
+        borderRadius: '4px',
+        padding: '8px 16px'
+      }}
+      declineButtonStyle={{
+        color: '#808080',
+        backgroundColor: 'transparent',
+        fontSize: '13px',
+        border: '1px solid #808080',
+        borderRadius: '4px',
+        padding: '7px 15px'
+      }}
+      expires={365}
+      enableDeclineButton
+      onAccept={() => {
+        setHasConsent(true);
+        initGA();
+        pageview(location.pathname + location.search);
+      }}
+    >
+      This website uses cookies to enhance the user experience and analyze site traffic.
+    </CookieConsent>
+  );
+}

--- a/app/config/analytics.ts
+++ b/app/config/analytics.ts
@@ -4,4 +4,4 @@
  */
 
 // Google Analytics tracking ID
-export const GA_TRACKING_ID = import.meta.env.VITE_GOOGLE_ANALYTICS_ID
+export const GA_TRACKING_ID = import.meta.env.VITE_GOOGLE_ANALYTICS_ID;

--- a/app/config/analytics.ts
+++ b/app/config/analytics.ts
@@ -1,0 +1,7 @@
+/**
+ * Configuration for analytics
+ * Centralizes access to environment variables for analytics
+ */
+
+// Google Analytics tracking ID
+export const GA_TRACKING_ID = import.meta.env.VITE_GOOGLE_ANALYTICS_ID

--- a/app/context/CookieConsentContext.tsx
+++ b/app/context/CookieConsentContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+interface CookieConsentContextType {
+  messageHasBeenSent: boolean;
+  setMessageHasBeenSent: (value: boolean) => void;
+}
+
+const CookieConsentContext = createContext<CookieConsentContextType | undefined>(undefined);
+
+export function CookieConsentProvider({ children }: { children: ReactNode }) {
+  const [messageHasBeenSent, setMessageHasBeenSent] = useState(false);
+
+  return (
+    <CookieConsentContext.Provider value={{ messageHasBeenSent, setMessageHasBeenSent }}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+}
+
+export function useCookieConsent() {
+  const context = useContext(CookieConsentContext);
+  if (context === undefined) {
+    throw new Error('useCookieConsent must be used within a CookieConsentProvider');
+  }
+  return context;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,6 +11,9 @@ import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/root';
 import './app.css';
+import ClientOnly from './components/ClientOnly';
+import CookieBanner from './components/CookieBanner';
+import { CookieConsentProvider } from './context/CookieConsentContext';
 
 export const links: Route.LinksFunction = () => [
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
@@ -82,7 +85,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        {children}
+        <CookieConsentProvider>
+          {children}
+          <ClientOnly>
+            <CookieBanner />
+          </ClientOnly>
+        </CookieConsentProvider>
         <ScrollRestoration data-testid="scroll-restoration" />
         <Scripts data-testid="scripts" />
       </body>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
+import { useCookieConsent } from '../context/CookieConsentContext';
 import { encodeTitle } from '~/components/SessionSidebar/utils';
 import AppLayout from '../components/AppLayout';
 import ChatHeaderContent from '../components/ChatHeaderContent';
@@ -25,6 +26,7 @@ export default function UnifiedSession() {
   const navigate = useNavigate();
   const location = useLocation();
   const chatState = useSimpleChat(urlSessionId);
+  const { setMessageHasBeenSent } = useCookieConsent();
 
   // State for view management - set initial view based on URL path
   const [activeView, setActiveView] = useState<'code' | 'preview' | 'data'>(() => {
@@ -127,9 +129,10 @@ export default function UnifiedSession() {
       if (e.key === 'Enter' && !e.shiftKey && !chatState.isStreaming) {
         e.preventDefault();
         chatState.sendMessage();
+        setMessageHasBeenSent(true);
       }
     },
-    [chatState.isStreaming, chatState.sendMessage]
+    [chatState.isStreaming, chatState.sendMessage, setMessageHasBeenSent]
   );
 
   // Handle suggestion selection directly
@@ -228,7 +231,10 @@ export default function UnifiedSession() {
             value={chatState.input}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
-            onSend={chatState.sendMessage}
+            onSend={() => {
+              chatState.sendMessage();
+              setMessageHasBeenSent(true);
+            }}
             disabled={chatState.isStreaming}
             inputRef={chatState.inputRef}
           />

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -1,0 +1,33 @@
+import ReactGA from 'react-ga4';
+import { GA_TRACKING_ID } from '../config/analytics';
+
+/**
+ * Initialize Google Analytics
+ */
+export const initGA = (): void => {
+  ReactGA.initialize(GA_TRACKING_ID);
+};
+
+/**
+ * Track page view
+ * @param path - The page path
+ */
+export const pageview = (path: string): void => {
+  ReactGA.send({ hitType: 'pageview', page: path });
+};
+
+/**
+ * Track custom event
+ * @param category - Event category
+ * @param action - Event action
+ * @param label - Event label (optional)
+ * @param value - Event value (optional)
+ */
+export const event = (category: string, action: string, label?: string, value?: number): void => {
+  ReactGA.event({
+    category,
+    action,
+    label,
+    value,
+  });
+};

--- a/notes/cookie.md
+++ b/notes/cookie.md
@@ -1,0 +1,79 @@
+# Cookie Consent and Google Analytics Implementation Plan
+
+## Packages to Install
+
+```bash
+pnpm install react-cookie-consent react-ga4 --save
+```
+
+## Implementation Steps
+
+1. **Set up Google Analytics property**
+   - Create a GA4 property in Google Analytics console
+   - Obtain Measurement ID (e.g., G-XXXXXXXXXX)
+
+Google gave me this:
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-3TJLJPPLFH"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-3TJLJPPLFH');
+</script>
+
+2. **Implement Cookie Consent Banner**
+
+   - Add the consent banner to app layout
+   - Configure with accept/decline options
+   - Set appropriate cookie expiration (e.g., 365 days)
+
+3. **Conditional GA Loading**
+
+   - Create utility to check for consent before loading GA
+   - Implement GA tracking only after consent is given
+   - Use the onAccept event handler to initialize GA
+
+4. **Layout Integration**
+
+   - Add the consent banner to app layout component
+   - Ensure banner displays prominently but doesn't interfere with UI
+   - Use default package styles initially
+
+5. **GA Implementation**
+   - Create GA initialization function
+   - Set up page view tracking
+   - Prepare for future custom event tracking
+
+## Code Implementation Plan
+
+1. **Add Cookie Consent Component to Layout**
+
+   - Integrate into the main app layout
+   - Configure with proper styling and text
+   - Set up accept/decline callbacks
+
+2. **Create GA Utility**
+
+   - Create a utility file for GA functions
+   - Implement initialization and tracking methods
+   - Add consent check before any tracking
+
+3. **Privacy Policy Update**
+   - Update or create privacy policy page
+   - Include details about cookie usage and tracking
+
+## Technical Considerations
+
+- Only load GA scripts after explicit consent
+- Store consent state in a cookie with appropriate expiration
+- Ensure decline option completely prevents GA loading
+- Plan for future authentication integration
+
+## Future Enhancements
+
+- Custom styling to match app theme
+- More granular consent options if needed
+- Additional analytics event tracking

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "call-ai": "0.6.1",
     "isbot": "^5.1.17",
     "react": "^19.0.0",
+    "react-cookie-consent": "^9.0.0",
     "react-dom": "^19.0.0",
+    "react-ga4": "^2.1.0",
     "react-markdown": "^10.1.0",
     "react-router": "^7.1.5",
     "use-fireproof": "0.20.0-dev-preview-60"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,15 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.0.0
+      react-cookie-consent:
+        specifier: ^9.0.0
+        version: 9.0.0(react@19.0.0)
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-ga4:
+        specifier: ^2.1.0
+        version: 2.1.0
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.0.10)(react@19.0.0)
@@ -3818,6 +3824,12 @@ packages:
     engines: { node: '>=14' }
     hasBin: true
 
+  js-cookie@2.2.1:
+    resolution:
+      {
+        integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==,
+      }
+
   js-cookie@3.0.5:
     resolution:
       {
@@ -4937,6 +4949,15 @@ packages:
       }
     engines: { node: '>= 0.8' }
 
+  react-cookie-consent@9.0.0:
+    resolution:
+      {
+        integrity: sha512-Blyj+m+Zz7SFHYqT18p16EANgnSg2sIyU6Yp3vk83AnOnSW7qnehPkUe4+8+qxztJrNmCH5GP+VHsWzAKVOoZA==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      react: '>=16'
+
   react-d3-tree@3.6.5:
     resolution:
       {
@@ -4978,6 +4999,12 @@ packages:
     engines: { node: '>=10', npm: '>=6' }
     peerDependencies:
       react: '>=16.13.1'
+
+  react-ga4@2.1.0:
+    resolution:
+      {
+        integrity: sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==,
+      }
 
   react-hotkeys-hook@4.6.1:
     resolution:
@@ -8612,6 +8639,8 @@ snapshots:
       js-cookie: 3.0.5
       nopt: 8.1.0
 
+  js-cookie@2.2.1: {}
+
   js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
@@ -9297,6 +9326,11 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-cookie-consent@9.0.0(react@19.0.0):
+    dependencies:
+      js-cookie: 2.2.1
+      react: 19.0.0
+
   react-d3-tree@3.6.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@bkrem/react-transition-group': 1.3.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9336,6 +9370,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.9
       react: 19.0.0
+
+  react-ga4@2.1.0: {}
 
   react-hotkeys-hook@4.6.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/tests/home-complete.test.tsx
+++ b/tests/home-complete.test.tsx
@@ -4,6 +4,15 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import UnifiedSession from '../app/routes/home';
 import * as segmentParser from '../app/utils/segmentParser';
 import * as useSimpleChatModule from '../app/hooks/useSimpleChat';
+
+// Mock the CookieConsentContext
+vi.mock('../app/context/CookieConsentContext', () => ({
+  useCookieConsent: () => ({
+    messageHasBeenSent: false,
+    setMessageHasBeenSent: vi.fn(),
+  }),
+  CookieConsentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 import type { ChatMessage, UserChatMessage, AiChatMessage, Segment } from '../app/types/chat';
 import { mockChatStateProps } from './mockData';
 

--- a/tests/home.test.tsx
+++ b/tests/home.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import UnifiedSession from '../app/routes/home';
 
+// Mock the CookieConsentContext
+vi.mock('../app/context/CookieConsentContext', () => ({
+  useCookieConsent: () => ({
+    messageHasBeenSent: false,
+    setMessageHasBeenSent: vi.fn(),
+  }),
+  CookieConsentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 // Mock dependencies
 vi.mock('../app/hooks/useSimpleChat', () => ({
   useSimpleChat: () => ({

--- a/tests/root.test.tsx
+++ b/tests/root.test.tsx
@@ -13,6 +13,27 @@ vi.mock('react-router', () => ({
     <div data-testid={testId} />
   ),
   isRouteErrorResponse: vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '' }),
+}));
+
+// Mock the cookie consent library
+vi.mock('react-cookie-consent', () => ({
+  default: ({ children, buttonText, onAccept }: any) => (
+    <div data-testid="cookie-consent">
+      {children}
+      <button onClick={onAccept}>{buttonText}</button>
+    </div>
+  ),
+  getCookieConsentValue: vi.fn().mockReturnValue(null),
+}));
+
+// Mock the CookieConsentContext
+vi.mock('../app/context/CookieConsentContext', () => ({
+  useCookieConsent: () => ({
+    messageHasBeenSent: false,
+    setMessageHasBeenSent: vi.fn(),
+  }),
+  CookieConsentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 describe('Root Component', () => {
@@ -39,10 +60,13 @@ describe('Root Component', () => {
   });
 
   it('renders the Layout component with children', () => {
+    // Use document.createElement to create a container to avoid hydration warnings
+    const container = document.createElement('div');
     render(
       <Layout>
         <div data-testid="test-child">Test Child</div>
-      </Layout>
+      </Layout>,
+      { container }
     );
 
     // Check that the layout renders the children
@@ -70,10 +94,13 @@ describe('Root Component', () => {
       })),
     });
 
+    // Use document.createElement to create a container to avoid hydration warnings
+    const container = document.createElement('div');
     render(
       <Layout>
         <div>Test</div>
-      </Layout>
+      </Layout>,
+      { container }
     );
 
     // Check that dark class is added to html element

--- a/tests/session.test.tsx
+++ b/tests/session.test.tsx
@@ -4,6 +4,15 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import UnifiedSession from '../app/routes/home';
 import * as segmentParser from '../app/utils/segmentParser';
 import * as useSimpleChatModule from '../app/hooks/useSimpleChat';
+
+// Mock the CookieConsentContext
+vi.mock('../app/context/CookieConsentContext', () => ({
+  useCookieConsent: () => ({
+    messageHasBeenSent: false,
+    setMessageHasBeenSent: vi.fn(),
+  }),
+  CookieConsentProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 import type { AiChatMessage } from '../app/types/chat';
 import { mockChatStateProps } from './mockData';
 
@@ -177,7 +186,7 @@ describe('Session Route Integration', () => {
   });
 
   it('displays the correct number of code lines in the preview', async () => {
-    // Render the UnifiedSession component directly
+    // Render the UnifiedSession component
     render(<UnifiedSession />);
 
     // Wait for and verify the code line count is displayed

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -9,7 +9,9 @@ type CookieConsentContextType = {
 };
 
 // Create a React Context with the same name as the app's context
-export const CookieConsentContext = React.createContext<CookieConsentContextType | undefined>(undefined);
+export const CookieConsentContext = React.createContext<CookieConsentContextType | undefined>(
+  undefined
+);
 
 // Create a provider component that matches the one in the app
 export function CookieConsentProvider({ children }: { children: React.ReactNode }) {
@@ -30,6 +32,6 @@ export function renderWithProviders(
   const AllProviders = ({ children }: { children: React.ReactNode }) => {
     return <CookieConsentProvider>{children}</CookieConsentProvider>;
   };
-  
+
   return render(ui, { wrapper: AllProviders, ...options });
 }

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
+
+// Create a mock CookieConsentContext
+type CookieConsentContextType = {
+  messageHasBeenSent: boolean;
+  setMessageHasBeenSent: (value: boolean) => void;
+};
+
+// Create a React Context with the same name as the app's context
+export const CookieConsentContext = React.createContext<CookieConsentContextType | undefined>(undefined);
+
+// Create a provider component that matches the one in the app
+export function CookieConsentProvider({ children }: { children: React.ReactNode }) {
+  const [messageHasBeenSent, setMessageHasBeenSent] = React.useState(false);
+
+  return (
+    <CookieConsentContext.Provider value={{ messageHasBeenSent, setMessageHasBeenSent }}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+}
+
+// Create a wrapper component that includes all necessary providers for testing
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  const AllProviders = ({ children }: { children: React.ReactNode }) => {
+    return <CookieConsentProvider>{children}</CookieConsentProvider>;
+  };
+  
+  return render(ui, { wrapper: AllProviders, ...options });
+}


### PR DESCRIPTION
- Implement cookie consent using react-cookie-consent
- Add Google Analytics integration with proper consent management
- Create ClientOnly component for proper SSR handling
- Add context-based message detection to show banner after first message
- Implement dark/light mode theming for cookie banner
- Move Google Analytics ID to environment variables