### PR TITLE
Jchris/fpWrapper

### DIFF
--- a/app/components/ResultPreview/DataView/DatabaseData.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseData.tsx
@@ -15,39 +15,22 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
   const namespacedDbName = `vx-${sessionId}-${dbName}`;
   const [availableDbs, setAvailableDbs] = useState<string[]>([]);
 
-  // Function to list all available databases
-  const listAllDatabases = async () => {
-    console.log('🔥 FIREPROOF DB INSPECTOR 🔥 Starting database inspection...', { dbName, namespacedDbName });
+  // Function to list available databases with the current session ID
+  const listSessionDatabases = async () => {
     try {
       // Check if the databases API is available
       if (typeof window.indexedDB.databases !== 'function') {
-        console.warn('🔥 FIREPROOF DB INSPECTOR 🔥 indexedDB.databases() is not supported in this browser');
         setAvailableDbs(['API not supported in this browser']);
         return;
       }
       
       // Get all available databases
       const databases = await window.indexedDB.databases();
-      // console.log('🔥 RAW DB LIST:', databases); // Log the raw response
-      
       const dbNames = databases.map(db => db.name).filter(Boolean) as string[];
-      setAvailableDbs(dbNames);
       
-      // console.log('🔥 FIREPROOF DB INSPECTOR 🔥 Available databases:', dbNames);
-      
-      // Look for databases matching our patterns
-      const originalDbMatches = dbNames.filter(name => name === dbName);
-      const namespacedDbMatches = dbNames.filter(name => name === namespacedDbName);
+      // Filter for databases with this session ID
       const sessionMatches = dbNames.filter(name => name?.includes(sessionId));
-      
-      // Filter the available databases list to only show those with the session ID
-      // This makes it easier to focus on the databases relevant to the current session
       setAvailableDbs(sessionMatches);
-      
-      console.log(`🔥 DB MATCHES for '${dbName}':
-        - Exact matches: ${originalDbMatches.length}
-        - Namespaced matches: ${namespacedDbMatches.length}
-        - Session ID matches: ${sessionMatches.length}`);
     } catch (err) {
       console.error('Error listing databases:', err);
       setAvailableDbs(['Error: ' + (err as Error).message]);
@@ -59,14 +42,8 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
     // Apply the patch as soon as the component mounts
     applyIndexedDBPatch(sessionId);
     
-    console.log('🔥 FIREPROOF DB inspection NAMESPACING 🔥 ' + dbName + ' → ' + namespacedDbName);
-    
-    // Immediate call for debugging
-    listAllDatabases();
-    
-    // Also add a button to manually trigger it later if needed
-    // Add a global refresh function for easier debugging via console
-    (window as any)._refreshDbList = listAllDatabases;
+    // Load the initial database list
+    listSessionDatabases();
   }, []);
 
   // With the IndexedDB patch, we should now be able to use the original dbName
@@ -92,7 +69,7 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
         <div className="mt-1">
           <p><strong>Session Databases ({availableDbs.length}):</strong></p>
           <button 
-            onClick={() => listAllDatabases()} 
+            onClick={() => listSessionDatabases()} 
             className="text-xs bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 rounded mr-2 mb-2"
           >
             Refresh DB List

--- a/app/components/ResultPreview/DataView/DatabaseData.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseData.tsx
@@ -23,13 +23,13 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
         setAvailableDbs(['API not supported in this browser']);
         return;
       }
-      
+
       // Get all available databases
       const databases = await window.indexedDB.databases();
-      const dbNames = databases.map(db => db.name).filter(Boolean) as string[];
-      
+      const dbNames = databases.map((db) => db.name).filter(Boolean) as string[];
+
       // Filter for databases with this session ID
-      const sessionMatches = dbNames.filter(name => name?.includes(sessionId));
+      const sessionMatches = dbNames.filter((name) => name?.includes(sessionId));
       setAvailableDbs(sessionMatches);
     } catch (err) {
       console.error('Error listing databases:', err);
@@ -41,7 +41,7 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
   useEffect(() => {
     // Apply the patch as soon as the component mounts
     applyIndexedDBPatch(sessionId);
-    
+
     // Load the initial database list
     listSessionDatabases();
   }, []);
@@ -60,24 +60,36 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
   // Create a simple debug display component
   const DbDebugInfo = () => (
     <details className="mb-2 text-sm">
-      <summary className="cursor-pointer text-blue-500 hover:text-blue-700">Database Inspection Details</summary>
-      <div className="pl-2 mt-1 border-l-2 border-gray-300">
-        <p><strong>Original DB Name:</strong> {dbName}</p>
-        <p><strong>Session ID:</strong> {sessionId}</p>
-        <p><strong>Namespaced DB Name:</strong> {namespacedDbName}</p>
-        <p><strong>Current DB Name:</strong> {database.name}</p>
+      <summary className="cursor-pointer text-blue-500 hover:text-blue-700">
+        Database Inspection Details
+      </summary>
+      <div className="mt-1 border-l-2 border-gray-300 pl-2">
+        <p>
+          <strong>Original DB Name:</strong> {dbName}
+        </p>
+        <p>
+          <strong>Session ID:</strong> {sessionId}
+        </p>
+        <p>
+          <strong>Namespaced DB Name:</strong> {namespacedDbName}
+        </p>
+        <p>
+          <strong>Current DB Name:</strong> {database.name}
+        </p>
         <div className="mt-1">
-          <p><strong>Session Databases ({availableDbs.length}):</strong></p>
-          <button 
-            onClick={() => listSessionDatabases()} 
-            className="text-xs bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 rounded mr-2 mb-2"
+          <p>
+            <strong>Session Databases ({availableDbs.length}):</strong>
+          </p>
+          <button
+            onClick={() => listSessionDatabases()}
+            className="mr-2 mb-2 rounded bg-blue-500 px-2 py-1 text-xs text-white hover:bg-blue-700"
           >
             Refresh DB List
           </button>
           <span className="text-xs text-gray-600">(Filtered by session ID: {sessionId})</span>
-          <ul className="list-disc pl-4 mt-1">
+          <ul className="mt-1 list-disc pl-4">
             {availableDbs.map((name, idx) => (
-              <li key={idx} className={name === namespacedDbName ? 'text-green-600 font-bold' : ''}>
+              <li key={idx} className={name === namespacedDbName ? 'font-bold text-green-600' : ''}>
                 {name}
               </li>
             ))}

--- a/app/components/ResultPreview/DataView/DatabaseData.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseData.tsx
@@ -3,6 +3,8 @@ import DynamicTable from './DynamicTable';
 import { headersForDocs } from './dynamicTableHelpers';
 // Import Fireproof for database access
 import { useFireproof } from 'use-fireproof';
+// Import the monkey patch utility
+import { applyIndexedDBPatch } from './indexedDBMonkeyPatch';
 
 // Component for displaying database data
 const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName, sessionId }) => {
@@ -52,8 +54,11 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
     }
   };
 
-  // Enhanced debug logging  
+  // Apply the IndexedDB monkey patch to ensure consistent namespacing with the iframe
   useEffect(() => {
+    // Apply the patch as soon as the component mounts
+    applyIndexedDBPatch(sessionId);
+    
     console.log('🔥 FIREPROOF DB inspection NAMESPACING 🔥 ' + dbName + ' → ' + namespacedDbName);
     
     // Immediate call for debugging
@@ -64,8 +69,9 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
     (window as any)._refreshDbList = listAllDatabases;
   }, []);
 
-  // Always use Fireproof with useLiveQuery for reactive data access
-  const { useAllDocs, database } = useFireproof(namespacedDbName);
+  // With the IndexedDB patch, we should now be able to use the original dbName
+  // and the patch will handle the namespacing at the IndexedDB.open level
+  const { useAllDocs, database } = useFireproof(dbName);
 
   // Always call hooks at the top level regardless of conditions
   // In Fireproof, useLiveQuery returns docs and potentially other properties

--- a/app/components/ResultPreview/DataView/DatabaseData.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseData.tsx
@@ -1,17 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DynamicTable from './DynamicTable';
 import { headersForDocs } from './dynamicTableHelpers';
 // Import Fireproof for database access
 import { useFireproof } from 'use-fireproof';
 
 // Component for displaying database data
-const DatabaseData: React.FC<{ dbName: string }> = ({ dbName }) => {
+const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName, sessionId }) => {
   if (!dbName) {
     throw new Error('No valid database name provided');
   }
 
+  const namespacedDbName = `vx-${sessionId}-${dbName}`;
+  const [availableDbs, setAvailableDbs] = useState<string[]>([]);
+
+  // Function to list all available databases
+  const listAllDatabases = async () => {
+    console.log('🔥 FIREPROOF DB INSPECTOR 🔥 Starting database inspection...', { dbName, namespacedDbName });
+    try {
+      // Check if the databases API is available
+      if (typeof window.indexedDB.databases !== 'function') {
+        console.warn('🔥 FIREPROOF DB INSPECTOR 🔥 indexedDB.databases() is not supported in this browser');
+        setAvailableDbs(['API not supported in this browser']);
+        return;
+      }
+      
+      // Get all available databases
+      const databases = await window.indexedDB.databases();
+      // console.log('🔥 RAW DB LIST:', databases); // Log the raw response
+      
+      const dbNames = databases.map(db => db.name).filter(Boolean) as string[];
+      setAvailableDbs(dbNames);
+      
+      // console.log('🔥 FIREPROOF DB INSPECTOR 🔥 Available databases:', dbNames);
+      
+      // Look for databases matching our patterns
+      const originalDbMatches = dbNames.filter(name => name === dbName);
+      const namespacedDbMatches = dbNames.filter(name => name === namespacedDbName);
+      const sessionMatches = dbNames.filter(name => name?.includes(sessionId));
+      
+      // Filter the available databases list to only show those with the session ID
+      // This makes it easier to focus on the databases relevant to the current session
+      setAvailableDbs(sessionMatches);
+      
+      console.log(`🔥 DB MATCHES for '${dbName}':
+        - Exact matches: ${originalDbMatches.length}
+        - Namespaced matches: ${namespacedDbMatches.length}
+        - Session ID matches: ${sessionMatches.length}`);
+    } catch (err) {
+      console.error('Error listing databases:', err);
+      setAvailableDbs(['Error: ' + (err as Error).message]);
+    }
+  };
+
+  // Enhanced debug logging  
+  useEffect(() => {
+    console.log('🔥 FIREPROOF DB inspection NAMESPACING 🔥 ' + dbName + ' → ' + namespacedDbName);
+    
+    // Immediate call for debugging
+    listAllDatabases();
+    
+    // Also add a button to manually trigger it later if needed
+    // Add a global refresh function for easier debugging via console
+    (window as any)._refreshDbList = listAllDatabases;
+  }, []);
+
   // Always use Fireproof with useLiveQuery for reactive data access
-  const { useAllDocs, database } = useFireproof(dbName);
+  const { useAllDocs, database } = useFireproof(namespacedDbName);
 
   // Always call hooks at the top level regardless of conditions
   // In Fireproof, useLiveQuery returns docs and potentially other properties
@@ -20,23 +74,55 @@ const DatabaseData: React.FC<{ dbName: string }> = ({ dbName }) => {
 
   const headers = docs.length > 0 ? headersForDocs(docs) : [];
 
+  // Create a simple debug display component
+  const DbDebugInfo = () => (
+    <details className="mb-2 text-sm">
+      <summary className="cursor-pointer text-blue-500 hover:text-blue-700">Database Inspection Details</summary>
+      <div className="pl-2 mt-1 border-l-2 border-gray-300">
+        <p><strong>Original DB Name:</strong> {dbName}</p>
+        <p><strong>Session ID:</strong> {sessionId}</p>
+        <p><strong>Namespaced DB Name:</strong> {namespacedDbName}</p>
+        <p><strong>Current DB Name:</strong> {database.name}</p>
+        <div className="mt-1">
+          <p><strong>Session Databases ({availableDbs.length}):</strong></p>
+          <button 
+            onClick={() => listAllDatabases()} 
+            className="text-xs bg-blue-500 hover:bg-blue-700 text-white py-1 px-2 rounded mr-2 mb-2"
+          >
+            Refresh DB List
+          </button>
+          <span className="text-xs text-gray-600">(Filtered by session ID: {sessionId})</span>
+          <ul className="list-disc pl-4 mt-1">
+            {availableDbs.map((name, idx) => (
+              <li key={idx} className={name === namespacedDbName ? 'text-green-600 font-bold' : ''}>
+                {name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </details>
+  );
+
   if (docs.length === 0) {
     return (
       <div className="bg-light-decorative-00 dark:bg-dark-decorative-00 rounded-lg p-4">
-        <p>Loading data from {dbName}...</p>
+        <DbDebugInfo />
+        <p>Loading data from {database.name}...</p>
       </div>
     );
   }
 
   return (
     <div className="">
+      <DbDebugInfo />
       <DynamicTable
         headers={headers}
         rows={docs}
         dbName={database.name}
         hrefFn={() => '#'}
         onRowClick={(docId: string, dbName: string) => {
-          console.log(`View document ${docId} from database ${dbName}`);
+          console.log(`View document ${docId} from database ${database.name}`);
         }}
       />
     </div>

--- a/app/components/ResultPreview/DataView/DatabaseData.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseData.tsx
@@ -121,7 +121,7 @@ const DatabaseData: React.FC<{ dbName: string; sessionId: string }> = ({ dbName,
         rows={docs}
         dbName={database.name}
         hrefFn={() => '#'}
-        onRowClick={(docId: string, dbName: string) => {
+        onRowClick={(docId: string) => {
           console.log(`View document ${docId} from database ${database.name}`);
         }}
       />

--- a/app/components/ResultPreview/DataView/DatabaseListView.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseListView.tsx
@@ -2,9 +2,9 @@ import React, { useMemo } from 'react';
 import DatabaseData from './DatabaseData';
 
 // Component to find and display database names from app code
-const DatabaseListView: React.FC<{ appCode: string; isDarkMode: boolean }> = ({
+const DatabaseListView: React.FC<{ appCode: string; sessionId: string }> = ({
   appCode,
-  isDarkMode,
+  sessionId,
 }) => {
   // Extract first 50 lines using memoization
   const firstFiftyLines = useMemo(() => {
@@ -36,7 +36,7 @@ const DatabaseListView: React.FC<{ appCode: string; isDarkMode: boolean }> = ({
           <h2 className="mb-2 text-lg font-medium">
             Data stored in <span className="font-mono">{databaseName}</span>
           </h2>
-          <DatabaseData dbName={databaseName} key={databaseName} />
+          {sessionId && <DatabaseData dbName={databaseName} key={databaseName} sessionId={sessionId} />}
         </div>
       )}
     </div>

--- a/app/components/ResultPreview/DataView/DatabaseListView.tsx
+++ b/app/components/ResultPreview/DataView/DatabaseListView.tsx
@@ -36,7 +36,9 @@ const DatabaseListView: React.FC<{ appCode: string; sessionId: string }> = ({
           <h2 className="mb-2 text-lg font-medium">
             Data stored in <span className="font-mono">{databaseName}</span>
           </h2>
-          {sessionId && <DatabaseData dbName={databaseName} key={databaseName} sessionId={sessionId} />}
+          {sessionId && (
+            <DatabaseData dbName={databaseName} key={databaseName} sessionId={sessionId} />
+          )}
         </div>
       )}
     </div>

--- a/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
+++ b/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
@@ -9,7 +9,7 @@ let isPatched = false;
 
 /**
  * Apply the IndexedDB monkeypatch for the current window
- * 
+ *
  * @param sessionId The session ID to use for namespacing
  */
 export const applyIndexedDBPatch = (sessionId: string): void => {
@@ -22,7 +22,7 @@ export const applyIndexedDBPatch = (sessionId: string): void => {
   const originalIndexedDBOpen = indexedDB.open;
 
   // Apply the monkey patch
-  indexedDB.open = function(name, ...args) {
+  indexedDB.open = function (name, ...args) {
     // Skip namespacing for non-Fireproof databases (must start with 'fp.')
     // This also implicitly skips databases like 'fp-keybag' that use a hyphen
     if (!name || !name.startsWith('fp.')) {

--- a/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
+++ b/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
@@ -1,6 +1,7 @@
 /**
- * This is a utility to monkey-patch the IndexedDB.open method for namespacing databases
- * It follows the exact same pattern as used in the iframe-template.html
+ * IndexedDB monkey-patch utility for namespacing databases
+ * This follows the same pattern as in iframe-template.html to ensure consistency
+ * between the parent window and iframe contexts
  */
 
 // Check if already patched to avoid double-patching
@@ -14,31 +15,27 @@ let isPatched = false;
 export const applyIndexedDBPatch = (sessionId: string): void => {
   // Avoid double-patching
   if (isPatched) {
-    console.log('🔥 FIREPROOF USERLAND PATCH 🔥 Already applied');
     return;
   }
 
   // Save the original method
   const originalIndexedDBOpen = indexedDB.open;
-  console.log('🔥 FIREPROOF USERLAND PATCH 🔥 Applying for session:', sessionId);
 
   // Apply the monkey patch
   indexedDB.open = function(name, ...args) {
-    // Skip namespacing for non-Fireproof databases (must start with 'fp.').
-    // NOTE: This also implicitly skips databases like 'fp-keybag' that use a hyphen.
+    // Skip namespacing for non-Fireproof databases (must start with 'fp.')
+    // This also implicitly skips databases like 'fp-keybag' that use a hyphen
     if (!name || !name.startsWith('fp.')) {
       return originalIndexedDBOpen.call(this, name, ...args);
     }
 
     // Skip namespacing for internal Vibes databases
     if (name.startsWith('fp.vibe-') || name.startsWith('fp.vibes-')) {
-      console.log('🔥 FIREPROOF USERLAND SKIPPING 🔥 Internal database:', name);
       return originalIndexedDBOpen.call(this, name, ...args);
     }
 
     // Skip if already namespaced (starts with vx-)
     if (name.includes('vx-')) {
-      console.log('🔥 FIREPROOF USERLAND SKIPPING 🔥 Already namespaced:', name);
       return originalIndexedDBOpen.call(this, name, ...args);
     }
 
@@ -46,7 +43,6 @@ export const applyIndexedDBPatch = (sessionId: string): void => {
     // Insert the vx-sessionId into the database name instead of prefixing the whole name
     const dbNameWithoutPrefix = name.substring(3); // Remove 'fp.' prefix
     const namespacedName = 'fp.vx-' + sessionId + '-' + dbNameWithoutPrefix;
-    console.log('🔥 FIREPROOF USERLAND NAMESPACING 🔥 ' + name + ' → ' + namespacedName);
     return originalIndexedDBOpen.call(this, namespacedName, ...args);
   };
 

--- a/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
+++ b/app/components/ResultPreview/DataView/indexedDBMonkeyPatch.ts
@@ -1,0 +1,55 @@
+/**
+ * This is a utility to monkey-patch the IndexedDB.open method for namespacing databases
+ * It follows the exact same pattern as used in the iframe-template.html
+ */
+
+// Check if already patched to avoid double-patching
+let isPatched = false;
+
+/**
+ * Apply the IndexedDB monkeypatch for the current window
+ * 
+ * @param sessionId The session ID to use for namespacing
+ */
+export const applyIndexedDBPatch = (sessionId: string): void => {
+  // Avoid double-patching
+  if (isPatched) {
+    console.log('🔥 FIREPROOF USERLAND PATCH 🔥 Already applied');
+    return;
+  }
+
+  // Save the original method
+  const originalIndexedDBOpen = indexedDB.open;
+  console.log('🔥 FIREPROOF USERLAND PATCH 🔥 Applying for session:', sessionId);
+
+  // Apply the monkey patch
+  indexedDB.open = function(name, ...args) {
+    // Skip namespacing for non-Fireproof databases (must start with 'fp.').
+    // NOTE: This also implicitly skips databases like 'fp-keybag' that use a hyphen.
+    if (!name || !name.startsWith('fp.')) {
+      return originalIndexedDBOpen.call(this, name, ...args);
+    }
+
+    // Skip namespacing for internal Vibes databases
+    if (name.startsWith('fp.vibe-') || name.startsWith('fp.vibes-')) {
+      console.log('🔥 FIREPROOF USERLAND SKIPPING 🔥 Internal database:', name);
+      return originalIndexedDBOpen.call(this, name, ...args);
+    }
+
+    // Skip if already namespaced (starts with vx-)
+    if (name.includes('vx-')) {
+      console.log('🔥 FIREPROOF USERLAND SKIPPING 🔥 Already namespaced:', name);
+      return originalIndexedDBOpen.call(this, name, ...args);
+    }
+
+    // Apply namespacing using the exact same pattern as in iframe-template.html
+    // Insert the vx-sessionId into the database name instead of prefixing the whole name
+    const dbNameWithoutPrefix = name.substring(3); // Remove 'fp.' prefix
+    const namespacedName = 'fp.vx-' + sessionId + '-' + dbNameWithoutPrefix;
+    console.log('🔥 FIREPROOF USERLAND NAMESPACING 🔥 ' + name + ' → ' + namespacedName);
+    return originalIndexedDBOpen.call(this, namespacedName, ...args);
+  };
+
+  // Mark as patched
+  isPatched = true;
+};

--- a/app/components/ResultPreview/IframeContent.tsx
+++ b/app/components/ResultPreview/IframeContent.tsx
@@ -324,7 +324,7 @@ const IframeContent: React.FC<IframeContentProps> = ({
         <div className="data-container">
           <DatabaseListView
             appCode={filesContent['/App.jsx']?.code || ''}
-            sessionId={sessionId || "default-session"}
+            sessionId={sessionId || 'default-session'}
           />
         </div>
       </div>

--- a/app/components/ResultPreview/IframeContent.tsx
+++ b/app/components/ResultPreview/IframeContent.tsx
@@ -100,7 +100,7 @@ const IframeContent: React.FC<IframeContentProps> = ({
 
       // Use the extracted function to normalize component export patterns
       const normalizedCode = normalizeComponentExports(appCode);
-      
+
       // Create a session ID variable for the iframe template
       const sessionIdValue = sessionId || 'default-session';
 

--- a/app/components/ResultPreview/IframeContent.tsx
+++ b/app/components/ResultPreview/IframeContent.tsx
@@ -19,6 +19,7 @@ interface IframeContentProps {
   setActiveView: (view: 'preview' | 'code' | 'data') => void;
   dependencies: Record<string, string>;
   isDarkMode: boolean; // Add isDarkMode prop
+  sessionId?: string; // Add sessionId prop
 }
 
 const IframeContent: React.FC<IframeContentProps> = ({
@@ -30,6 +31,7 @@ const IframeContent: React.FC<IframeContentProps> = ({
   dependencies,
   setActiveView,
   isDarkMode, // Receive the isDarkMode prop
+  sessionId, // Receive the sessionId prop
 }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // Theme state is now received from parent via props
@@ -98,6 +100,9 @@ const IframeContent: React.FC<IframeContentProps> = ({
 
       // Use the extracted function to normalize component export patterns
       const normalizedCode = normalizeComponentExports(appCode);
+      
+      // Create a session ID variable for the iframe template
+      const sessionIdValue = sessionId || 'default-session';
 
       // Transform bare import statements to use esm.sh URLs
       const transformImports = (code: string): string => {
@@ -126,7 +131,8 @@ const IframeContent: React.FC<IframeContentProps> = ({
       // Use the template and replace placeholders
       const htmlContent = iframeTemplateRaw
         .replace('{{API_KEY}}', CALLAI_API_KEY)
-        .replace('{{APP_CODE}}', transformedCode);
+        .replace('{{APP_CODE}}', transformedCode)
+        .replace('{{SESSION_ID}}', sessionIdValue);
 
       const blob = new Blob([htmlContent], { type: 'text/html' });
       const url = URL.createObjectURL(blob);

--- a/app/components/ResultPreview/IframeContent.tsx
+++ b/app/components/ResultPreview/IframeContent.tsx
@@ -17,7 +17,6 @@ interface IframeContentProps {
   codeReady: boolean;
 
   setActiveView: (view: 'preview' | 'code' | 'data') => void;
-  dependencies: Record<string, string>;
   isDarkMode: boolean; // Add isDarkMode prop
   sessionId?: string; // Add sessionId prop
 }
@@ -26,9 +25,7 @@ const IframeContent: React.FC<IframeContentProps> = ({
   activeView,
   filesContent,
   isStreaming,
-
   codeReady,
-  dependencies,
   setActiveView,
   isDarkMode, // Receive the isDarkMode prop
   sessionId, // Receive the sessionId prop
@@ -327,7 +324,7 @@ const IframeContent: React.FC<IframeContentProps> = ({
         <div className="data-container">
           <DatabaseListView
             appCode={filesContent['/App.jsx']?.code || ''}
-            isDarkMode={isDarkMode}
+            sessionId={sessionId || "default-session"}
           />
         </div>
       </div>

--- a/app/components/ResultPreview/ResultPreview.tsx
+++ b/app/components/ResultPreview/ResultPreview.tsx
@@ -181,6 +181,7 @@ function ResultPreview({
       setActiveView={setActiveView}
       dependencies={dependencies}
       isDarkMode={isDarkMode} // Pass down the theme state
+      sessionId={sessionId} // Pass the sessionId to IframeContent
     />
   );
 

--- a/app/components/ResultPreview/ResultPreview.tsx
+++ b/app/components/ResultPreview/ResultPreview.tsx
@@ -179,7 +179,7 @@ function ResultPreview({
       isStreaming={!codeReady} // Pass the derived prop
       codeReady={codeReady}
       setActiveView={setActiveView}
-      dependencies={dependencies}
+      /* dependencies prop removed */
       isDarkMode={isDarkMode} // Pass down the theme state
       sessionId={sessionId} // Pass the sessionId to IframeContent
     />

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -172,16 +172,16 @@
     <script>
       window.CALLAI_API_KEY = '{{API_KEY}}';
       window.SESSION_ID = '{{SESSION_ID}}';
-      
+
       // Set up a proxy for Fireproof database namespacing
       window.FireproofWrapper = {
         sessionId: window.SESSION_ID || 'default-session',
-        wrapDbName: function(name) {
+        wrapDbName: function (name) {
           if (!name) {
             return `${this.sessionId}-default-db`;
           }
           return `${this.sessionId}-${name}`;
-        }
+        },
       };
     </script>
     <script type="importmap">
@@ -196,47 +196,47 @@
         }
       }
     </script>
-    
+
     <!-- Custom import map handler script to intercept use-fireproof imports -->
     <script type="module">
       // Import this from inside a module script
       import { useFireproof } from 'use-fireproof';
-      
+
       // Create a sessionId-prefixed wrapper for useFireproof
       const wrappedUseFireproof = (...args) => {
         const sessionId = window.SESSION_ID || 'default-session';
         let modifiedArgs = [...args];
-        
+
         // Add session ID prefix to database name
         if (args.length === 0) {
           modifiedArgs = [`${sessionId}-default-db`];
         } else if (typeof args[0] === 'string') {
           modifiedArgs[0] = `${sessionId}-${args[0]}`;
         }
-        
+
         console.log(`Fireproof wrapper: using database '${modifiedArgs[0]}'`);
         return useFireproof(...modifiedArgs);
       };
-      
+
       // Expose the wrapped version to the window for our APP_CODE to use
       window.fireproofHooks = { wrappedUseFireproof };
     </script>
-    
+
     <script type="text/babel" data-type="module">
       import ReactDOMClient from 'react-dom/client';
-      
+
       // Import our wrapped version at the top of the module
       import { useFireproof as originalUseFireproof } from 'use-fireproof';
 
       // This makes the wrapped version available in the global scope
       // before the APP_CODE is executed
       window.useFireproof = window.fireproofHooks.wrappedUseFireproof;
-      
+
       // The APP_CODE will be injected here
       // prettier-ignore
       {{APP_CODE}}
       // prettier-ignore-end
-      
+
       const rootElement = document.getElementById('container');
       ReactDOMClient.createRoot(rootElement).render(<App />);
     </script>

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -192,7 +192,11 @@
       const originalIndexedDBOpen = indexedDB.open;
       const sessionId = window.SESSION_ID || 'default-session';
       
-      // Replace it with our wrapped version - only for Fireproof databases, with exceptions
+      /*
+       * Replace with our wrapped version - only for Fireproof databases, with exceptions
+       * This namespacing follows the same pattern used in DatabaseData.tsx: fp.vx-[sessionId]-[originalName]
+       * So a database named 'fp.ai-playlist-db' would become 'fp.vx-sessionId-ai-playlist-db'
+       */
       indexedDB.open = function(name, ...args) {
         // Skip namespacing for non-Fireproof databases (must start with 'fp.').
         // NOTE: This also implicitly skips databases like 'fp-keybag' that use a hyphen.
@@ -206,16 +210,19 @@
           return originalIndexedDBOpen.call(this, name, ...args);
         }
         
-        // Skip if already namespaced (starts with v-)
+        // Skip if already namespaced (starts with v-) - handles namespacing from DataView/DatabaseData.tsx
         if (name.startsWith('v-')) {
           console.log('🔥 FIREPROOF SKIPPING 🔥 Already namespaced: ' + name);
           return originalIndexedDBOpen.call(this, name, ...args);
         }
         
         // Apply namespacing to all other Fireproof databases
-        const prefixedName = 'v-' + sessionId + '-' + name;
-        console.log('🔥 FIREPROOF DB NAMESPACING 🔥 ' + name + ' → ' + prefixedName);
-        return originalIndexedDBOpen.call(this, prefixedName, ...args);
+        // IMPORTANT: This pattern must match what's used in DataView/DatabaseData.tsx
+        // Insert the vx-sessionId into the database name instead of prefixing the whole name
+        const dbNameWithoutPrefix = name.substring(3); // Remove 'fp.' prefix
+        const namespacedName = 'fp.vx-' + sessionId + '-' + dbNameWithoutPrefix;
+        console.log('🔥 FIREPROOF DB NAMESPACING 🔥 ' + name + ' → ' + namespacedName);
+        return originalIndexedDBOpen.call(this, namespacedName, ...args);
       };
     </script>
     

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -171,6 +171,18 @@
     <div id="container"></div>
     <script>
       window.CALLAI_API_KEY = '{{API_KEY}}';
+      window.SESSION_ID = '{{SESSION_ID}}';
+      
+      // Set up a proxy for Fireproof database namespacing
+      window.FireproofWrapper = {
+        sessionId: window.SESSION_ID || 'default-session',
+        wrapDbName: function(name) {
+          if (!name) {
+            return `${this.sessionId}-default-db`;
+          }
+          return `${this.sessionId}-${name}`;
+        }
+      };
     </script>
     <script type="importmap">
       {
@@ -184,14 +196,47 @@
         }
       }
     </script>
+    
+    <!-- Custom import map handler script to intercept use-fireproof imports -->
+    <script type="module">
+      // Import this from inside a module script
+      import { useFireproof } from 'use-fireproof';
+      
+      // Create a sessionId-prefixed wrapper for useFireproof
+      const wrappedUseFireproof = (...args) => {
+        const sessionId = window.SESSION_ID || 'default-session';
+        let modifiedArgs = [...args];
+        
+        // Add session ID prefix to database name
+        if (args.length === 0) {
+          modifiedArgs = [`${sessionId}-default-db`];
+        } else if (typeof args[0] === 'string') {
+          modifiedArgs[0] = `${sessionId}-${args[0]}`;
+        }
+        
+        console.log(`Fireproof wrapper: using database '${modifiedArgs[0]}'`);
+        return useFireproof(...modifiedArgs);
+      };
+      
+      // Expose the wrapped version to the window for our APP_CODE to use
+      window.fireproofHooks = { wrappedUseFireproof };
+    </script>
+    
     <script type="text/babel" data-type="module">
       import ReactDOMClient from 'react-dom/client';
+      
+      // Import our wrapped version at the top of the module
+      import { useFireproof as originalUseFireproof } from 'use-fireproof';
 
-      // APP_CODE placeholder will be replaced with actual code
+      // This makes the wrapped version available in the global scope
+      // before the APP_CODE is executed
+      window.useFireproof = window.fireproofHooks.wrappedUseFireproof;
+      
+      // The APP_CODE will be injected here
       // prettier-ignore
       {{APP_CODE}}
       // prettier-ignore-end
-
+      
       const rootElement = document.getElementById('container');
       ReactDOMClient.createRoot(rootElement).render(<App />);
     </script>

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -206,13 +206,11 @@
         
         // Skip namespacing for internal Vibes databases
         if (name.startsWith('fp.vibe-') || name.startsWith('fp.vibes-')) {
-          console.log('🔥 FIREPROOF SKIPPING 🔥 Internal database: ' + name);
           return originalIndexedDBOpen.call(this, name, ...args);
         }
         
         // Skip if already namespaced (starts with v-) - handles namespacing from DataView/DatabaseData.tsx
         if (name.startsWith('v-')) {
-          console.log('🔥 FIREPROOF SKIPPING 🔥 Already namespaced: ' + name);
           return originalIndexedDBOpen.call(this, name, ...args);
         }
         
@@ -221,7 +219,6 @@
         // Insert the vx-sessionId into the database name instead of prefixing the whole name
         const dbNameWithoutPrefix = name.substring(3); // Remove 'fp.' prefix
         const namespacedName = 'fp.vx-' + sessionId + '-' + dbNameWithoutPrefix;
-        console.log('🔥 FIREPROOF DB NAMESPACING 🔥 ' + name + ' → ' + namespacedName);
         return originalIndexedDBOpen.call(this, namespacedName, ...args);
       };
     </script>

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -194,7 +194,8 @@
       
       // Replace it with our wrapped version - only for Fireproof databases, with exceptions
       indexedDB.open = function(name, ...args) {
-        // Skip namespacing for non-Fireproof databases
+        // Skip namespacing for non-Fireproof databases (must start with 'fp.').
+        // NOTE: This also implicitly skips databases like 'fp-keybag' that use a hyphen.
         if (!name || !name.startsWith('fp.')) {
           return originalIndexedDBOpen.call(this, name, ...args);
         }

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -191,29 +191,29 @@
       // Save the original indexedDB.open method
       const originalIndexedDBOpen = indexedDB.open;
       const sessionId = window.SESSION_ID || 'default-session';
-      
+
       /*
        * Replace with our wrapped version - only for Fireproof databases, with exceptions
        * This namespacing follows the same pattern used in DatabaseData.tsx: fp.vx-[sessionId]-[originalName]
        * So a database named 'fp.ai-playlist-db' would become 'fp.vx-sessionId-ai-playlist-db'
        */
-      indexedDB.open = function(name, ...args) {
+      indexedDB.open = function (name, ...args) {
         // Skip namespacing for non-Fireproof databases (must start with 'fp.').
         // NOTE: This also implicitly skips databases like 'fp-keybag' that use a hyphen.
         if (!name || !name.startsWith('fp.')) {
           return originalIndexedDBOpen.call(this, name, ...args);
         }
-        
+
         // Skip namespacing for internal Vibes databases
         if (name.startsWith('fp.vibe-') || name.startsWith('fp.vibes-')) {
           return originalIndexedDBOpen.call(this, name, ...args);
         }
-        
+
         // Skip if already namespaced (starts with v-) - handles namespacing from DataView/DatabaseData.tsx
         if (name.startsWith('v-')) {
           return originalIndexedDBOpen.call(this, name, ...args);
         }
-        
+
         // Apply namespacing to all other Fireproof databases
         // IMPORTANT: This pattern must match what's used in DataView/DatabaseData.tsx
         // Insert the vx-sessionId into the database name instead of prefixing the whole name
@@ -222,15 +222,15 @@
         return originalIndexedDBOpen.call(this, namespacedName, ...args);
       };
     </script>
-    
+
     <script type="text/babel" data-type="module">
       import ReactDOMClient from 'react-dom/client';
-      
+
       // App runs normally without our interference, but the iframe loads our script to modify use-fireproof
       // prettier-ignore
       {{APP_CODE}}
       // prettier-ignore-end
-      
+
       const rootElement = document.getElementById('container');
       ReactDOMClient.createRoot(rootElement).render(<App />);
     </script>

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -178,9 +178,9 @@
         sessionId: window.SESSION_ID || 'default-session',
         wrapDbName: function (name) {
           if (!name) {
-            return `${this.sessionId}-default-db`;
+            return `v-${this.sessionId}-default-db`;
           }
-          return `${this.sessionId}-${name}`;
+          return `v-${this.sessionId}-${name}`;
         },
       };
     </script>
@@ -197,41 +197,61 @@
       }
     </script>
 
-    <!-- Custom import map handler script to intercept use-fireproof imports -->
-    <script type="module">
-      // Import this from inside a module script
-      import { useFireproof } from 'use-fireproof';
-
-      // Create a sessionId-prefixed wrapper for useFireproof
-      const wrappedUseFireproof = (...args) => {
-        const sessionId = window.SESSION_ID || 'default-session';
-        let modifiedArgs = [...args];
-
-        // Add session ID prefix to database name
-        if (args.length === 0) {
-          modifiedArgs = [`${sessionId}-default-db`];
-        } else if (typeof args[0] === 'string') {
-          modifiedArgs[0] = `${sessionId}-${args[0]}`;
-        }
-
-        console.log(`Fireproof wrapper: using database '${modifiedArgs[0]}'`);
-        return useFireproof(...modifiedArgs);
-      };
-
-      // Expose the wrapped version to the window for our APP_CODE to use
-      window.fireproofHooks = { wrappedUseFireproof };
+    <!-- Setup direct ES module interception for use-fireproof -->
+    <script>
+      // Create our import map interceptor - this needs to run before any modules load
+      (function() {
+        // Store the original import map
+        const originalImportMap = document.querySelector('script[type="importmap"]').textContent;
+        const importMap = JSON.parse(originalImportMap);
+        
+        // Save the original URL
+        const originalFireproofUrl = importMap.imports['use-fireproof'];
+        
+        // Create a proxy URL that will intercept all imports
+        const proxyUrl = URL.createObjectURL(new Blob([
+          `// Proxy module for use-fireproof
+          import * as originalModule from '${originalFireproofUrl}';
+          
+          // Create wrapped useFireproof function
+          export function useFireproof(...args) {
+            // Get session ID from window
+            const sessionId = window.SESSION_ID || 'default-session';
+            let modifiedArgs = [...args];
+            
+            // Add v- prefix and session ID to database name
+            if (args.length === 0) {
+              modifiedArgs = ['v-' + sessionId + '-default-db'];
+            } else if (typeof args[0] === 'string') {
+              modifiedArgs[0] = 'v-' + sessionId + '-' + args[0];
+            }
+            
+            console.log('🔥 FIREPROOF WRAPPER 🔥 Database name:', modifiedArgs[0]);
+            return originalModule.useFireproof(...modifiedArgs);
+          }
+          
+          // Re-export everything else from the original module
+          export const { fireproof, connectStorageSource, createSyncAdapter, lf, localFirst, connectIdb, connectWeb } = originalModule;
+          `
+        ], { type: 'application/javascript' }));
+        
+        // Update the import map to use our proxy URL
+        importMap.imports['use-fireproof'] = proxyUrl;
+        
+        // Replace the original import map with our modified one
+        document.querySelector('script[type="importmap"]').textContent = JSON.stringify(importMap, null, 2);
+        
+        // Clean up when we're done
+        window.addEventListener('unload', () => URL.revokeObjectURL(proxyUrl));
+      })();
     </script>
 
     <script type="text/babel" data-type="module">
       import ReactDOMClient from 'react-dom/client';
-
-      // Import our wrapped version at the top of the module
-      import { useFireproof as originalUseFireproof } from 'use-fireproof';
-
-      // This makes the wrapped version available in the global scope
-      // before the APP_CODE is executed
-      window.useFireproof = window.fireproofHooks.wrappedUseFireproof;
-
+      
+      // No need for extra import handling, our import map is already intercepting
+      // any imports of use-fireproof with our wrapped version
+      
       // The APP_CODE will be injected here
       // prettier-ignore
       {{APP_CODE}}

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -172,17 +172,6 @@
     <script>
       window.CALLAI_API_KEY = '{{API_KEY}}';
       window.SESSION_ID = '{{SESSION_ID}}';
-
-      // Set up a proxy for Fireproof database namespacing
-      window.FireproofWrapper = {
-        sessionId: window.SESSION_ID || 'default-session',
-        wrapDbName: function (name) {
-          if (!name) {
-            return `v-${this.sessionId}-default-db`;
-          }
-          return `v-${this.sessionId}-${name}`;
-        },
-      };
     </script>
     <script type="importmap">
       {
@@ -197,66 +186,28 @@
       }
     </script>
 
-    <!-- Setup direct ES module interception for use-fireproof -->
+    <!-- IndexedDB hook to prefix database names with session ID -->
     <script>
-      // Create our import map interceptor - this needs to run before any modules load
-      (function() {
-        // Store the original import map
-        const originalImportMap = document.querySelector('script[type="importmap"]').textContent;
-        const importMap = JSON.parse(originalImportMap);
-        
-        // Save the original URL
-        const originalFireproofUrl = importMap.imports['use-fireproof'];
-        
-        // Create a proxy URL that will intercept all imports
-        const proxyUrl = URL.createObjectURL(new Blob([
-          `// Proxy module for use-fireproof
-          import * as originalModule from '${originalFireproofUrl}';
-          
-          // Create wrapped useFireproof function
-          export function useFireproof(...args) {
-            // Get session ID from window
-            const sessionId = window.SESSION_ID || 'default-session';
-            let modifiedArgs = [...args];
-            
-            // Add v- prefix and session ID to database name
-            if (args.length === 0) {
-              modifiedArgs = ['v-' + sessionId + '-default-db'];
-            } else if (typeof args[0] === 'string') {
-              modifiedArgs[0] = 'v-' + sessionId + '-' + args[0];
-            }
-            
-            console.log('🔥 FIREPROOF WRAPPER 🔥 Database name:', modifiedArgs[0]);
-            return originalModule.useFireproof(...modifiedArgs);
-          }
-          
-          // Re-export everything else from the original module
-          export const { fireproof, connectStorageSource, createSyncAdapter, lf, localFirst, connectIdb, connectWeb } = originalModule;
-          `
-        ], { type: 'application/javascript' }));
-        
-        // Update the import map to use our proxy URL
-        importMap.imports['use-fireproof'] = proxyUrl;
-        
-        // Replace the original import map with our modified one
-        document.querySelector('script[type="importmap"]').textContent = JSON.stringify(importMap, null, 2);
-        
-        // Clean up when we're done
-        window.addEventListener('unload', () => URL.revokeObjectURL(proxyUrl));
-      })();
+      // Save the original indexedDB.open method
+      const originalIndexedDBOpen = indexedDB.open;
+      const sessionId = window.SESSION_ID || 'default-session';
+      
+      // Replace it with our wrapped version
+      indexedDB.open = function(name, ...args) {
+        const prefixedName = 'v-' + sessionId + '-' + name;
+        console.log('🔥 FIREPROOF DB NAMESPACING 🔥 ' + name + ' → ' + prefixedName);
+        return originalIndexedDBOpen.call(this, prefixedName, ...args);
+      };
     </script>
-
+    
     <script type="text/babel" data-type="module">
       import ReactDOMClient from 'react-dom/client';
       
-      // No need for extra import handling, our import map is already intercepting
-      // any imports of use-fireproof with our wrapped version
-      
-      // The APP_CODE will be injected here
+      // App runs normally without our interference, but the iframe loads our script to modify use-fireproof
       // prettier-ignore
       {{APP_CODE}}
       // prettier-ignore-end
-
+      
       const rootElement = document.getElementById('container');
       ReactDOMClient.createRoot(rootElement).render(<App />);
     </script>

--- a/app/components/ResultPreview/templates/iframe-template.html
+++ b/app/components/ResultPreview/templates/iframe-template.html
@@ -192,8 +192,26 @@
       const originalIndexedDBOpen = indexedDB.open;
       const sessionId = window.SESSION_ID || 'default-session';
       
-      // Replace it with our wrapped version
+      // Replace it with our wrapped version - only for Fireproof databases, with exceptions
       indexedDB.open = function(name, ...args) {
+        // Skip namespacing for non-Fireproof databases
+        if (!name || !name.startsWith('fp.')) {
+          return originalIndexedDBOpen.call(this, name, ...args);
+        }
+        
+        // Skip namespacing for internal Vibes databases
+        if (name.startsWith('fp.vibe-') || name.startsWith('fp.vibes-')) {
+          console.log('🔥 FIREPROOF SKIPPING 🔥 Internal database: ' + name);
+          return originalIndexedDBOpen.call(this, name, ...args);
+        }
+        
+        // Skip if already namespaced (starts with v-)
+        if (name.startsWith('v-')) {
+          console.log('🔥 FIREPROOF SKIPPING 🔥 Already namespaced: ' + name);
+          return originalIndexedDBOpen.call(this, name, ...args);
+        }
+        
+        // Apply namespacing to all other Fireproof databases
         const prefixedName = 'v-' + sessionId + '-' + name;
         console.log('🔥 FIREPROOF DB NAMESPACING 🔥 ' + name + ' → ' + prefixedName);
         return originalIndexedDBOpen.call(this, prefixedName, ...args);

--- a/app/data/models.json
+++ b/app/data/models.json
@@ -10,7 +10,7 @@
     "description": "Fast coding assistant (cloaked)"
   },
   {
-    "id":"qwen/qwen-2.5-coder-32b-instruct",
+    "id": "qwen/qwen-2.5-coder-32b-instruct",
     "name": "Qwen 2.5 Coder 32B Instruct",
     "description": "Latest Qwen code-specific model with improved generation, reasoning, and fixing capabilities"
   },

--- a/app/data/models.json
+++ b/app/data/models.json
@@ -10,7 +10,7 @@
     "description": "Fast coding assistant (cloaked)"
   },
   {
-    "id": "qwen/qwen-2.5-coder-32b-instruct",
+    "id":"qwen/qwen-2.5-coder-32b-instruct",
     "name": "Qwen 2.5 Coder 32B Instruct",
     "description": "Latest Qwen code-specific model with improved generation, reasoning, and fixing capabilities"
   },


### PR DESCRIPTION
# Session-specific Database Namespacing for Injected Apps

## Problem
Injected apps using `use-fireproof` would all share the same database namespace, causing data collisions between different sessions and injected applications.

## Solution
Implemented a transparent session-specific database namespacing mechanism for the `use-fireproof` module that:

1. Passes the `sessionId` from parent components through to the iframe
2. Creates a wrapper around the original `useFireproof` hook that automatically prefixes database names with the session ID
3. Makes the wrapped version available in the global scope for injected app code

## Implementation Details

- **Component Chain**: Updated the data flow from `ResultPreview` → `IframeContent` → iframe template
- **Session ID Injection**: Added `window.SESSION_ID` to the iframe template
- **Module Wrapping**: Created a module-level wrapper that imports the original hook and creates a wrapped version
- **Transparent Usage**: Injected apps don't need to change their code - they can continue using `import { useFireproof } from 'use-fireproof'` as normal

This approach ensures that each injected app in different sessions has isolated storage without requiring any changes to the app code itself.

## Benefits

- Prevents data collisions between different sessions
- Maintains backward compatibility with existing app code
- Zero-configuration for injected app developers
- Preserves all the functionality of the original module