### PR TITLE
Add footer with 'Powered by Fireproof - Join the Discord'

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import LightUpYourData from './ResultPreview/LightUpYourData';
-
+import Footer from './Footer';
 interface AppLayoutProps {
   chatPanel: ReactNode;
   previewPanel: ReactNode;
@@ -25,11 +25,13 @@ export default function AppLayout({
   fullWidthChat = false,
 }: AppLayoutProps) {
   return (
-    <div className="relative flex h-dvh flex-col md:flex-row md:overflow-hidden">
+    <div className='h-dvh'>
       {/* Background component that covers the entire viewport */}
-      <div className="absolute inset-0 z-0 h-full w-full overflow-hidden">
+      <div className="absolute inset-0 z-0 h-full w-full pointer-events-none overflow-hidden">
         <LightUpYourData />
       </div>
+
+    <div className="relative flex h-[calc(100%-2rem)] flex-col md:flex-row md:overflow-hidden">
 
       {/* Content with relative positioning to appear above the background */}
       <div
@@ -57,7 +59,6 @@ export default function AppLayout({
           </div>
         </div>
       </div>
-
       <div
         className={`flex w-full flex-col ${fullWidthChat ? 'md:w-0' : 'md:w-2/3'} ${
           mobilePreviewShown ? 'h-full' : 'h-auto overflow-visible opacity-100 md:h-full'
@@ -73,6 +74,8 @@ export default function AppLayout({
 
         <div className="w-full">{appInfo}</div>
       </div>
+    </div>
+    <Footer/>
     </div>
   );
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,9 +2,9 @@ export default function Footer() {
     return (
         <footer className="text-center text-xs pb-2">
             <p>
-                Powered by <a href="https://use-fireproof.com" className="cursor-pointer underline">Fireproof</a>
+                Powered by <a href="https://use-fireproof.com" className="cursor-pointer">Fireproof</a>
                 &ensp;&ndash;&ensp;Join
-                us on <a href="https://discord.gg/xC55bhgf6n" className="cursor-pointer underline">Discord</a>
+                us on <a href="https://discord.gg/xC55bhgf6n" className="cursor-pointer">Discord</a>
             </p>
         </footer>
     )

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
             <p>
                 Powered by <a href="https://use-fireproof.com" className="cursor-pointer">Fireproof</a>
                 &ensp;&ndash;&ensp;Join
-                us on <a href="https://discord.gg/xC55bhgf6n" className="cursor-pointer">Discord</a>
+                us on <a href="https://discord.gg/vnpWycj4Ta" className="cursor-pointer">Discord</a>
             </p>
         </footer>
     )

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,11 @@
+export default function Footer() {
+    return (
+        <footer className="text-center text-xs pb-2">
+            <p>
+                Powered by <a href="https://use-fireproof.com" className="cursor-pointer underline">Fireproof</a>
+                &ensp;&ndash;&ensp;Join
+                us on <a href="https://discord.gg/xC55bhgf6n" className="cursor-pointer underline">Discord</a>
+            </p>
+        </footer>
+    )
+}


### PR DESCRIPTION
After this change there's a super minimal footer on vibes.diy: "Powered by Fireproof - Join our Discord" with a link for each.

I understand "Powered by Fireproof" should eventually go to use-vibes.com. Just probably not this week.

### Screenshots

<img width="400" alt="Screenshot 2025-04-14 at 2 52 08 PM" src="https://github.com/user-attachments/assets/501fa103-cba0-477b-95e3-12c57f847d11" />

<img width="300" alt="Screenshot 2025-04-14 at 2 52 36 PM" src="https://github.com/user-attachments/assets/6510049d-86a5-4320-8b27-ab6ab7694794" />