### PR TITLE
Improve test coverage

### DIFF
--- a/tests/PublishMenu.test.tsx
+++ b/tests/PublishMenu.test.tsx
@@ -1,0 +1,66 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PublishMenu } from '../app/components/PublishMenu';
+import { trackPublishClick } from '../app/utils/analytics';
+
+vi.mock('../app/utils/analytics', () => ({
+  trackPublishClick: vi.fn(),
+}));
+
+describe('PublishMenu', () => {
+  const button = document.createElement('button');
+  document.body.appendChild(button);
+  const ref = { current: button } as React.RefObject<HTMLButtonElement>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    (trackPublishClick as any).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <PublishMenu isOpen={false} onClose={() => {}} onPublish={async () => {}} buttonRef={ref} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('copies URL and tracks click', () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { getByLabelText } = render(
+      <PublishMenu
+        isOpen={true}
+        onClose={() => {}}
+        onPublish={async () => {}}
+        buttonRef={ref}
+        publishedAppUrl="https://example.com/app"
+      />
+    );
+
+    const copyBtn = getByLabelText('Copy to clipboard');
+    fireEvent.click(copyBtn);
+    expect(writeText).toHaveBeenCalledWith('https://example.com/app');
+    expect(trackPublishClick).toHaveBeenCalledWith({ publishedAppUrl: 'https://example.com/app' });
+    // success icon shows
+    expect(getByLabelText('Copied to clipboard')).toBeInTheDocument();
+
+    vi.runAllTimers();
+  });
+
+  it('shows spinner during publishing', async () => {
+    const publish = vi.fn().mockResolvedValue(undefined);
+    const { getByText, getByLabelText } = render(
+      <PublishMenu isOpen onClose={() => {}} onPublish={publish} buttonRef={ref} />
+    );
+
+    fireEvent.click(getByText('Publish App'));
+    expect(publish).toHaveBeenCalled();
+    expect(getByLabelText('Publishing in progress')).toBeInTheDocument();
+  });
+});

--- a/tests/authUtils.test.ts
+++ b/tests/authUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseToken, verifyToken } from '../app/utils/auth';
+
+// helper to create a simple base64url encoded string
+const b64url = (str: string) => Buffer.from(str).toString('base64url');
+
+describe('auth utils', () => {
+  describe('parseToken', () => {
+    it('returns payload for valid token', () => {
+      const payload = { userId: '123', exp: 9999999999 };
+      const token = `${b64url('{}')}.${b64url(JSON.stringify(payload))}.sig`;
+      expect(parseToken(token)).toEqual(payload);
+    });
+
+    it('returns null for malformed token', () => {
+      expect(parseToken('bad.token')).toBeNull();
+    });
+  });
+
+  describe('verifyToken', () => {
+    beforeEach(() => {
+      // ensure DEV mode so verifyToken short circuits
+      (import.meta as any).env = { DEV: true };
+    });
+
+    it('returns true in DEV environment', async () => {
+      await expect(verifyToken('any.token')).resolves.toBe(true);
+    });
+  });
+});

--- a/tests/encodeTitle.test.ts
+++ b/tests/encodeTitle.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { encodeTitle } from '../app/components/SessionSidebar/utils';
+
+describe('encodeTitle', () => {
+  it('converts spaces and special characters to hyphenated encoding', () => {
+    expect(encodeTitle('Hello World!')).toBe('hello-world-');
+    expect(encodeTitle('My_App 2024')).toBe('my_app-2024');
+  });
+
+  it('uses default when empty title provided', () => {
+    expect(encodeTitle('')).toBe('untitled-chat');
+  });
+});


### PR DESCRIPTION
## Summary
- add direct tests for auth utils
- test encodeTitle behavior
- cover PublishMenu component interactions

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6839f5891bbc8323b88b3040f1657a4a