### PR TITLE
Implement flexible pre-chat layout

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -11,6 +11,9 @@ interface AppLayoutProps {
   mobilePreviewShown?: boolean;
   appInfo?: ReactNode;
   fullWidthChat?: boolean;
+  heroComponent?: ReactNode;
+  recentProjectsComponent?: ReactNode;
+  isPreChat?: boolean;
 }
 
 export default function AppLayout({
@@ -23,6 +26,9 @@ export default function AppLayout({
   mobilePreviewShown = false,
   appInfo,
   fullWidthChat = false,
+  heroComponent,
+  recentProjectsComponent,
+  isPreChat = false,
 }: AppLayoutProps) {
   return (
     <div className="relative flex h-dvh flex-col md:flex-row md:overflow-hidden">
@@ -31,30 +37,36 @@ export default function AppLayout({
         <LightUpYourData />
       </div>
 
-      {/* Content with relative positioning to appear above the background */}
+      {/* Chat column */}
       <div
         className={`flex w-full flex-col ${fullWidthChat ? 'md:w-full' : 'md:w-1/3'} ${
           mobilePreviewShown ? 'hidden md:flex md:h-full' : 'h-full'
         } relative z-10 transition-all duration-300 ease-in-out`}
       >
-        <div className="flex h-[4rem] items-center p-2">{headerLeft}</div>
+        <div className="flex h-full flex-col">
+          {isPreChat && heroComponent ? (
+            <header className="flex-shrink-0 transition-all duration-300">
+              {heroComponent}
+            </header>
+          ) : (
+            <header className="flex-shrink-0 h-[4rem]">{headerLeft}</header>
+          )}
 
-        <div className="flex-grow overflow-auto">{chatPanel}</div>
+          <main className="flex-grow overflow-auto">{chatPanel}</main>
 
-        {suggestionsComponent && (
-          <div className={`w-full ${fullWidthChat ? 'md:flex md:justify-center' : ''}`}>
-            <div className={`${fullWidthChat ? 'md:w-4/5' : 'w-full'}`}>{suggestionsComponent}</div>
-          </div>
-        )}
+          <footer className="flex-shrink-0">{chatInput}</footer>
 
-        <div
-          className={`w-full ${fullWidthChat ? 'md:flex md:justify-center md:pb-[20vh]' : 'pb-0'} transition-all duration-300 ease-in-out`}
-        >
-          <div
-            className={`${fullWidthChat ? 'md:w-4/5' : 'w-full'} transition-all duration-300 ease-in-out`}
-          >
-            {chatInput}
-          </div>
+          {isPreChat && suggestionsComponent && (
+            <div className={`w-full ${fullWidthChat ? 'md:flex md:justify-center' : ''}`}>
+              <div className={`${fullWidthChat ? 'md:w-4/5' : 'w-full'}`}>{suggestionsComponent}</div>
+            </div>
+          )}
+
+          {isPreChat && recentProjectsComponent && (
+            <aside className="flex-shrink-0 transition-all duration-300">
+              {recentProjectsComponent}
+            </aside>
+          )}
         </div>
       </div>
 

--- a/app/components/ChatInterface.tsx
+++ b/app/components/ChatInterface.tsx
@@ -60,7 +60,7 @@ function ChatInterface({
         </div>
       ) : (
         <div className="flex flex-grow flex-col justify-between">
-          <div className="flex-grow pb-4">
+          <div className="flex-grow">
             <WelcomeScreen />
           </div>
         </div>

--- a/app/components/RecentVibes.tsx
+++ b/app/components/RecentVibes.tsx
@@ -1,0 +1,24 @@
+import { useVibes } from '../hooks/useVibes';
+import { VibeCardData } from './VibeCardData';
+
+export default function RecentVibes() {
+  const { vibes } = useVibes();
+  const recent = vibes.slice(0, 5);
+
+  if (recent.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 py-4">
+      <h3 className="text-accent-01 mb-2 text-center text-sm font-medium">
+        Recent Vibes
+      </h3>
+      <div className="grid grid-cols-1 gap-4">
+        {recent.map((vibe) => (
+          <VibeCardData key={vibe.id} vibeId={vibe.id} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -7,6 +7,8 @@ import ChatHeaderContent from '../components/ChatHeaderContent';
 import ChatInput from '../components/ChatInput';
 import ChatInterface from '../components/ChatInterface';
 import QuickSuggestions from '../components/QuickSuggestions';
+import RecentVibes from '../components/RecentVibes';
+import WelcomeScreen from '../components/WelcomeScreen';
 import ResultPreview from '../components/ResultPreview/ResultPreview';
 import ResultPreviewHeaderContent from '../components/ResultPreview/ResultPreviewHeaderContent';
 import SessionSidebar from '../components/SessionSidebar';
@@ -230,14 +232,21 @@ export default function UnifiedSession() {
     }
   }, [chatState.sessionId, chatState.title, navigate, location.pathname, setActiveView]);
 
-  // Switch to 2-column view immediately when a message is submitted
-  const shouldUseFullWidthChat =
+  const isPreChat =
     chatState.docs.length === 0 && !urlSessionId && !hasSubmittedMessage;
+
+  const fullWidthChat = isPreChat;
+
+  const heroComponent = isPreChat ? <WelcomeScreen /> : null;
+  const recentProjectsComponent = isPreChat ? <RecentVibes /> : null;
 
   return (
     <>
       <AppLayout
-        fullWidthChat={shouldUseFullWidthChat}
+        fullWidthChat={fullWidthChat}
+        heroComponent={heroComponent}
+        recentProjectsComponent={recentProjectsComponent}
+        isPreChat={isPreChat}
         headerLeft={
           <ChatHeaderContent
             remixOf={chatState.vibeDoc?.remixOf}
@@ -305,7 +314,7 @@ export default function UnifiedSession() {
           />
         }
         suggestionsComponent={
-          chatState.docs.length === 0 ? (
+          isPreChat ? (
             <QuickSuggestions onSelectSuggestion={handleSelectSuggestion} />
           ) : undefined
         }


### PR DESCRIPTION
## Summary
- refactor `AppLayout` with hero/recent slots for pre‑chat state
- update home route to show welcome screen and recent vibes before chat
- anchor chat interface using flexbox and show hero before messages
- remove accidentally added `package-lock.json`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6839f7adf0a88323b9c026f46eb545a5